### PR TITLE
Atualiza versão

### DIFF
--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2019042008;
+$plugin->version = 2020051301;
 $plugin->requires = 2016120500;
 $plugin->cron = 0;
 $plugin->component = 'mod_bigbluebuttonbn';


### PR DESCRIPTION
Versão 2.3(2019042008) esta como versão menor que a versão 2.2 (2019050801), sem essa correção não é possível atualizar o plugin